### PR TITLE
[feature/refactor-contents-app-views-and-endpoints] 책조회, 도서검색 

### DIFF
--- a/api/contents/book_object/serializers.py
+++ b/api/contents/book_object/serializers.py
@@ -66,3 +66,6 @@ class DetailBookListSerializer(serializers.ModelSerializer):
     class Meta:
         model = BookObject
         fields = ['isbn', 'title', 'author', 'publisher', 'thumbnail']
+
+    def to_representation(self, instance):
+        return dict(super(DetailBookListSerializer, self).to_representation(instance))

--- a/api/contents/book_object/serializers.py
+++ b/api/contents/book_object/serializers.py
@@ -60,3 +60,9 @@ class SimpleBookListSerializer(serializers.ModelSerializer):
     class Meta:
         model = BookObject
         fields = ['isbn']
+
+
+class DetailBookListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BookObject
+        fields = ['isbn', 'title', 'author', 'publisher', 'thumbnail']

--- a/api/contents/book_object/urls.py
+++ b/api/contents/book_object/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from api.contents.book_object.views import *
+
+app_name = 'books'
+
+urlpatterns = [
+    path('new', BookView.as_view(), name='book_new'),
+    path('search/tagging', TaggingBookSearchAPIView.as_view(), name='tagging_book_search'),
+    path('search/navbar', NavbarBookSearchAPIView.as_view(), name='navbar_book_search'),
+]

--- a/api/contents/book_object/views.py
+++ b/api/contents/book_object/views.py
@@ -68,6 +68,15 @@ class TaggingBookSearchAPIView(generics.RetrieveAPIView):
     serializer_class = DetailBookListSerializer
     queryset = BookObject.objects.all()
 
+    def get_search_class_result(self, request):
+        param = self.request.GET
+        if param is {}:
+            return None
+
+        q = param.get('query', '') or param.get('isbn', '')
+        display = param.get('display', '')
+        return self.search_class(q, display)
+
     @swagger_auto_schema(
         operation_id='tagging_book_search',
         operation_description='페이지 생성시 등록할 도서에 대한 검색을 수행합니다.\n\n'
@@ -96,15 +105,6 @@ class TaggingBookSearchAPIView(generics.RetrieveAPIView):
         },
         security=[]
     )
-    def get_search_class_result(self, request):
-        param = self.request.GET
-        if param is {}:
-            return None
-
-        q = param.get('query', '') or param.get('isbn', '')
-        display = param.get('display', '')
-        return self.search_class(q, display)
-
     def get(self, request, *args, **kwargs):
         result = self.get_search_class_result(request)
         if result is None:

--- a/api/contents/book_object/views.py
+++ b/api/contents/book_object/views.py
@@ -74,8 +74,8 @@ class TaggingBookSearchAPIView(generics.RetrieveAPIView):
                               'parameter로는 검색어 또는 isbn 문자열 중 하나의 값만 전달할 수 있습니다.\n\n'
                               '두 개의 값을 모두 전달할 경우, 검색어가 우선 적용됩니다.',
         manual_parameters=[
-            swagger_parameter('query', openapi.IN_QUERY, '검색어', openapi.TYPE_STRING),
-            swagger_parameter('isbn', openapi.IN_QUERY, 'isbn 문자열', openapi.TYPE_STRING),
+            swagger_parameter('query', openapi.IN_QUERY, '검색어', openapi.TYPE_STRING, required=True),
+            swagger_parameter('isbn', openapi.IN_QUERY, 'isbn 문자열', openapi.TYPE_STRING, required=True),
             swagger_parameter('display', openapi.IN_QUERY, '검색결과 수', openapi.TYPE_INTEGER),
         ],
         responses={

--- a/api/contents/note/urls.py
+++ b/api/contents/note/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from api.contents.note.views import *
+
+app_name = 'notes'
+
+urlpatterns = [
+    path('new', NoteView.as_view(http_method_names=['post']), name='note_new'),
+    path('<int:pk>', NoteView.as_view(http_method_names=['get']), name='note_detail'),
+    path('<int:pk>/delete', NoteView.as_view(http_method_names=['delete']), name='note_delete'),
+    path('<int:pk>/like', NoteLikeView.as_view(http_method_names=['post']), name='note_like'),
+    path('<int:pk>/like/cancel', NoteLikeView.as_view(http_method_names=['delete']), name='note_like_cancel'),
+
+]

--- a/api/contents/page/urls.py
+++ b/api/contents/page/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+
+from api.contents.page.views import *
+
+app_name = 'pages'
+
+urlpatterns = [
+    path('new', PageView.as_view(http_method_names=['post']), name='page_new'),
+    path('<int:pk>', PageView.as_view(http_method_names=['get']), name='page_detail'),
+    path('<int:pk>/edit', PageView.as_view(http_method_names=['patch']), name='page_edit'),
+    path('<int:pk>/delete', PageView.as_view(http_method_names=['delete']), name='page_delete'),
+    path('<int:pk>/like', PageLikeView.as_view(http_method_names=['post']), name='page_like'),
+    path('<int:pk>/like/cancel', PageLikeView.as_view(http_method_names=['delete']), name='page_like_cancel'),
+
+]

--- a/api/contents/page_comment/urls.py
+++ b/api/contents/page_comment/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from api.contents.page_comment.views import *
+
+app_name = 'page_comments'
+
+urlpatterns = [
+    path('new', PageCommentView.as_view(http_method_names=['post']), name='page_comment_new'),
+    path('<int:pk>', PageCommentView.as_view(http_method_names=['get']), name='page_comment_detail'),
+    path('<int:pk>/edit', PageCommentView.as_view(http_method_names=['patch']), name='page_comment_edit'),
+    path('<int:pk>/delete', PageCommentView.as_view(http_method_names=['delete']), name='page_comment_delete'),
+]

--- a/api/contents/urls.py
+++ b/api/contents/urls.py
@@ -1,33 +1,10 @@
-from django.urls import path
-
-from api.contents.book_object.views import *
-from api.contents.note.views import *
-from api.contents.page.views import *
-from api.contents.page_comment.views import *
-
+from django.urls import include, path
 
 app_name = 'contents'
 
 urlpatterns = [
-    path('tagging/search', TaggingBookSearchAPIView.as_view(), name='tagging_book_search'),
-    path('navbar/search', NavbarBookSearchAPIView.as_view(), name='navbar_book_search'),
-
-    path('book/new', BookView.as_view(), name='book_new'),
-    path('notes/new', NoteView.as_view(http_method_names=['post']), name='note_new'),
-    path('notes/<int:pk>', NoteView.as_view(http_method_names=['get']), name='note_detail'),
-    path('notes/<int:pk>/delete', NoteView.as_view(http_method_names=['delete']), name='note_delete'),
-    path('notes/<int:pk>/like', NoteLikeView.as_view(http_method_names=['post']), name='note_like'),
-    path('notes/<int:pk>/like/cancel', NoteLikeView.as_view(http_method_names=['delete']), name='note_like_cancel'),
-
-    path('pages/new', PageView.as_view(http_method_names=['post']), name='page_new'),
-    path('pages/<int:pk>', PageView.as_view(http_method_names=['get']), name='page_detail'),
-    path('pages/<int:pk>/edit', PageView.as_view(http_method_names=['patch']), name='page_edit'),
-    path('pages/<int:pk>/delete', PageView.as_view(http_method_names=['delete']), name='page_delete'),
-    path('pages/<int:pk>/like', PageLikeView.as_view(http_method_names=['post']), name='page_like'),
-    path('pages/<int:pk>/like/cancel', PageLikeView.as_view(http_method_names=['delete']), name='page_like_cancel'),
-
-    path('page_comments/new', PageCommentView.as_view(http_method_names=['post']), name='page_comment_new'),
-    path('page_comments/<int:pk>', PageCommentView.as_view(http_method_names=['get']), name='page_comment_detail'),
-    path('page_comments/<int:pk>/edit', PageCommentView.as_view(http_method_names=['patch']), name='page_comment_edit'),
-    path('page_comments/<int:pk>/delete', PageCommentView.as_view(http_method_names=['delete']), name='page_comment_delete'),
+    path('books/', include('api.contents.book_object.urls')),
+    path('notes/', include('api.contents.note.urls')),
+    path('pages/', include('api.contents.page.urls')),
+    path('page_comments/', include('api.contents.page_comment.urls')),
 ]

--- a/api/contents/urls.py
+++ b/api/contents/urls.py
@@ -10,6 +10,7 @@ app_name = 'contents'
 
 urlpatterns = [
     path('tagging/search', TaggingBookSearchAPIView.as_view(), name='tagging_book_search'),
+    path('navbar/search', NavbarBookSearchAPIView.as_view(), name='navbar_book_search'),
 
     path('book/new', BookView.as_view(), name='book_new'),
     path('notes/new', NoteView.as_view(http_method_names=['post']), name='note_new'),

--- a/api/contents/urls.py
+++ b/api/contents/urls.py
@@ -9,7 +9,7 @@ from api.contents.page_comment.views import *
 app_name = 'contents'
 
 urlpatterns = [
-    path('naver/search', NaverSearchAPIView.as_view(), name='naver_search'),
+    path('tagging/search', TaggingBookSearchAPIView.as_view(), name='tagging_book_search'),
 
     path('book/new', BookView.as_view(), name='book_new'),
     path('notes/new', NoteView.as_view(http_method_names=['post']), name='note_new'),

--- a/api/main/serializers.py
+++ b/api/main/serializers.py
@@ -20,7 +20,7 @@ class UserMainSchemaSerializer(serializers.Serializer):
     user = UserSerializer(help_text='사용자', read_only=True)
 
 
-class MainBookListSchemaSerializer(serializers.Serializer):
+class MainNoteListSchemaSerializer(serializers.Serializer):
     note_id = serializers.IntegerField(help_text='노트 id', read_only=True)
     isbn = serializers.CharField(help_text='도서 isbn 문자열', read_only=True)
     datetime = serializers.DateTimeField(help_text='등록일자', read_only=True)

--- a/api/main/urls.py
+++ b/api/main/urls.py
@@ -7,5 +7,5 @@ app_name = 'main'
 urlpatterns = [
     path('', MainView.as_view(), name='main'),
     path('<int:pk>', UserMainView.as_view(), name='user_main'),
-    path('<int:pk>/books', BookListView.as_view(), name='main_book_list'),
+    path('<int:pk>/notes', NoteListView.as_view(), name='main_note_list'),
 ]

--- a/api/main/views.py
+++ b/api/main/views.py
@@ -9,7 +9,7 @@ from rest_framework import generics, mixins, status
 from rest_framework.response import Response
 
 from api.contents.book_object.serializers import SimpleBookListSerializer
-from api.main.serializers import MainSchemaSerializer, UserMainSchemaSerializer, MainBookListSchemaSerializer
+from api.main.serializers import MainSchemaSerializer, UserMainSchemaSerializer, MainNoteListSchemaSerializer
 from api.contents.note.serializers import NoteSerializer
 from api.contents.page.serializers import PageSerializer, PageDetailSerializer
 from api.users.serializers import UserSerializer
@@ -20,7 +20,7 @@ from core.exceptions import UserNotFound
 from core.views import TemplateMainView
 
 from utils.swagger import swagger_response, swagger_parameter, main_response_example, user_main_response_example, \
-    UserFailCaseCollection as user_fail_case, main_book_list_response_example
+    UserFailCaseCollection as user_fail_case, main_note_list_response_example
 
 
 class MainView(TemplateMainView):
@@ -111,20 +111,20 @@ class SearchView(generics.GenericAPIView, mixins.RetrieveModelMixin):
         return None
 
 
-class BookListView(generics.RetrieveAPIView):
+class NoteListView(generics.RetrieveAPIView):
     queryset = Note.objects.all().select_related('book__isbn')
     serializer_class = SimpleBookListSerializer
 
     @swagger_auto_schema(
-        operation_id='main_book_list',
-        operation_description='사용자가 등록한 책 정보(isbn, 등록일)를 조회합니다.',
+        operation_id='main_note_list',
+        operation_description='사용자가 필사한 책 정보(isbn, 등록일)를 조회합니다.',
         request_body=no_body,
         manual_parameters=[swagger_parameter('id', openapi.IN_PATH, '사용자 id', openapi.TYPE_INTEGER)],
         responses={
             200: swagger_response(
-                description='MAIN_BOOK_LIST_200',
-                schema=MainBookListSchemaSerializer,
-                examples=main_book_list_response_example
+                description='MAIN_NOTE_LIST_200',
+                schema=MainNoteListSchemaSerializer,
+                examples=main_note_list_response_example
             )
         }
     )

--- a/utils/swagger.py
+++ b/utils/swagger.py
@@ -347,14 +347,16 @@ def swagger_response(description=None, schema=None, examples=None):
     )
 
 
-def swagger_parameter(name, in_, description, type_, pattern=None):
-    return openapi.Parameter(
+def swagger_parameter(name, in_, description, type_, pattern=None, required=None):
+    param = openapi.Parameter(
         name=name,
         in_=in_,
         description=description,
         type=type_,
         pattern=pattern
     )
+    param.required = True if in_ == openapi.IN_PATH else (required or False)
+    return param
 
 
 def swagger_schema_with_properties(type_, properties):

--- a/utils/swagger.py
+++ b/utils/swagger.py
@@ -320,7 +320,7 @@ user_main_response_example = {
     "user": user_response_example
 }
 
-main_book_list_response_example = [
+main_note_list_response_example = [
     {
         "note_id": 1,
         "isbn": "9781501923579",


### PR DESCRIPTION
### 1. 기능 업데이트
- 필사한 책 조회용 endpoint 수정: `main_book_list` → `main_note_list`
- 도서 검색용 endpoint 구체화
   1. 페이지 생성용 도서검색
       - `tag_book_search`
       - `contents/books/search/tagging?query={query}`
       - 검색어에 대한 무작위 도서 검색. 별도의 정렬 없이 naver 검색 결과를 리턴
   2. 네브바용 도서검색
       - `navbar_book_search`
       - `contents/books/search/navbar?query={query}`
       - 사용자가 필사한 노트 수가 많은 순서대로 정렬한 도서 검색결과를 리턴. 

### 2. 문서 업데이트
- swagger parameter를 type(`IN_QUERY`, `IN_PATH`)에 따라 구체화

### 3. 코드 리팩토링
- contents app의 urls.py를 package 단위로 분리
- 도서정보를 리턴하는 serializer를 세분화 (`SimpleBookListSerializer`, `DetailBookListSerializer`)